### PR TITLE
動画のジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.genre_list(params[:genre])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params[:genre] == "php"
+      "PHP"
+    else
+      "Ruby/Rails"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,15 @@
 class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+  PHP_GENRE_LIST = %w[php]
+
+  def self.genre_list(genre)
+    if genre == "php"
+      where(genre: Movie::PHP_GENRE_LIST)
+    else
+      where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mw-xl">
   <div class="contents-title text-center">
-    <h1>Ruby/Rails 動画</h1>
+    <h1><%= movie_title %> 動画</h1>
   </div>
   <div class="container-fluid">
     <div class="row">


### PR DESCRIPTION
close #19 

## 実装内容
- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする