### PR TITLE
テキストジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,7 @@
 class TextsController < ApplicationController
   def index
     @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre_list(params[:genre])
   end
 
   def show; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,14 @@ module ApplicationHelper
     end
   end
 
+  def text_title
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
+
   def movie_title
     if params[:genre] == "php"
       "PHP"

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,15 @@
 class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+  PHP_GENRE_LIST = %w[php]
+
+  def self.genre_list(genre)
+    if genre == "php"
+      where(genre: Movie::PHP_GENRE_LIST)
+    else
+      where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,4 @@
-<h1 class="text-center mt-2 mb-4">Ruby/Rails
-  <br class="d-sm-none">テキスト教材
+<h1 class="text-center mt-2 mb-4"><%= text_title %><br class="d-sm-none">
 </h1>
 <div class="row">
   <%= render partial: "text", collection: @texts %>


### PR DESCRIPTION
close #21 

## 実装内容
- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする